### PR TITLE
Add the CsrManager for the Post-Processing SIMD datapath

### DIFF
--- a/src/main/scala/simd/CsrManager.scala
+++ b/src/main/scala/simd/CsrManager.scala
@@ -1,0 +1,143 @@
+package simd
+
+import chisel3._
+import chisel3.util._
+
+/** simplified csr read/write cmd
+  *
+  * @param csrAddrWidth
+  *   csr registers address width
+  */
+class CsrReq(csrAddrWidth: Int) extends Bundle {
+  val data = UInt(32.W)
+  val addr = UInt(csrAddrWidth.W)
+  val write = Bool()
+}
+
+class CsrRsp extends Bundle {
+  val data = UInt(32.W)
+}
+
+/** This class represents the csr input and output ports of the streamer top
+  * module
+  *
+  * @param csrAddrWidth
+  *   csr registers address width
+  */
+class CsrReqRspIO(csrAddrWidth: Int) extends Bundle {
+
+  val req = Flipped(Decoupled(new CsrReq(csrAddrWidth)))
+  val rsp = Decoupled(new CsrRsp)
+
+}
+
+/** This class represents the input and output ports of the CsrManager module.
+  * The input is connected to the SNAX CSR port. The output is connected to the
+  * streamer configuration port.
+  * @param csrNum
+  *   the number of csr registers
+  * @param csrAddrWidth
+  *   the width of the address
+  */
+class CsrManagerIO(
+    csrNum: Int,
+    csrAddrWidth: Int
+) extends Bundle {
+
+  val csr_config_in = new CsrReqRspIO(csrAddrWidth)
+  val csr_config_out = Decoupled(Vec(csrNum, UInt(32.W)))
+
+}
+
+/** This class represents the CsrManager module. It contains the csr registers
+  * and the read and write control logic.
+  * @param csrNum
+  *   the number of csr registers
+  * @param csrAddrWidth
+  *   the width of the address
+  */
+class CsrManager(
+    csrNum: Int,
+    csrAddrWidth: Int
+) extends Module
+    with RequireAsyncReset {
+
+  val io = IO(new CsrManagerIO(csrNum, csrAddrWidth))
+
+  // generate a vector of registers to store the csr state
+  val csr = RegInit(VecInit(Seq.fill(csrNum)(0.U(32.W))))
+
+  // read and write csr cmd
+  val read_csr = io.csr_config_in.req.fire && !io.csr_config_in.req.bits.write
+  val write_csr = io.csr_config_in.req.fire && io.csr_config_in.req.bits.write
+
+  // keep sending response to a read request until we receive the response ready signal
+  val keep_sending_csr_rsp = RegNext(
+    io.csr_config_in.rsp.valid && !io.csr_config_in.rsp.ready
+  )
+  // a register to store the read request response data until the request is successful
+  val csr_rsp_data_reg = RegInit(0.U(32.W))
+
+  // store the csr data for later output because the address only valid when io.csr.fire
+  csr_rsp_data_reg := Mux(
+    read_csr,
+    csr(io.csr_config_in.req.bits.addr),
+    csr_rsp_data_reg
+  )
+
+  // streamer configuration valid signal
+  val config_valid = WireInit(0.B)
+
+  // check if the csr address overflow (access certain csr that doesn't exist)
+  def startCsrAddr = (csrNum - 1).U
+
+  when(io.csr_config_in.req.fire) {
+
+    assert(
+      io.csr_config_in.req.bits.addr <= startCsrAddr,
+      "csr address overflow!"
+    )
+
+  }
+
+  // write req
+  when(write_csr) {
+    csr(io.csr_config_in.req.bits.addr) := io.csr_config_in.req.bits.data
+  }
+
+  // handle read requests: keep sending response data until the request succeeds
+  when(read_csr) {
+    io.csr_config_in.rsp.bits.data := csr(io.csr_config_in.req.bits.addr)
+    io.csr_config_in.rsp.valid := 1.B
+  }.elsewhen(keep_sending_csr_rsp) {
+    io.csr_config_in.rsp.bits.data := csr_rsp_data_reg
+    io.csr_config_in.rsp.valid := 1.B
+  }.otherwise {
+    io.csr_config_in.rsp.valid := 0.B
+    io.csr_config_in.rsp.bits.data := 0.U
+  }
+
+  // we are ready for a new request if two conditions hold:
+  // if we write to the config_valid register (the last one), the streamer must not be busy (io.csr_config_out.ready)
+  // if there is a read request in progress, we only accept new write requests
+  io.csr_config_in.req.ready := (io.csr_config_out.ready || !(io.csr_config_in.req.bits.addr === startCsrAddr)) && (!keep_sending_csr_rsp || io.csr_config_in.req.bits.write)
+
+  // a write/read to the last csr means the config is valid
+  config_valid := io.csr_config_in.req.fire && (io.csr_config_in.req.bits.addr === startCsrAddr)
+
+  // signals connected to the output ports
+  io.csr_config_out.bits <> csr
+  io.csr_config_out.valid <> config_valid
+
+}
+
+// Scala main function for generating CsrManager system verilog file
+object CsrManager extends App {
+  emitVerilog(
+    new CsrManager(
+      SIMDConstant.csrNum,
+      SIMDConstant.csrAddrWidth
+    ),
+    Array("--target-dir", "generated/csr_manager")
+  )
+}

--- a/src/main/scala/simd/Parameter.scala
+++ b/src/main/scala/simd/Parameter.scala
@@ -14,4 +14,9 @@ object SIMDConstant {
 
   // SIMD parallelism
   def laneLen = 64
+
+  // csrManager parameters, we use 3 csr for Post-processing SIMD
+  def csrNum: Int = 3 + 1
+  def csrAddrWidth: Int = log2Up(csrNum)
+
 }

--- a/src/main/scala/simd/Parameter.scala
+++ b/src/main/scala/simd/Parameter.scala
@@ -15,7 +15,7 @@ object SIMDConstant {
   // SIMD parallelism
   def laneLen = 64
 
-  // csrManager parameters, we use 3 csr for Post-processing SIMD
+  // csrManager parameters, we use 3 CSR for Post-processing SIMD configuration, + 1 for status CSR
   def csrNum: Int = 3 + 1
   def csrAddrWidth: Int = log2Up(csrNum)
 

--- a/src/main/scala/simd/SIMDTop.scala
+++ b/src/main/scala/simd/SIMDTop.scala
@@ -1,0 +1,64 @@
+package simd
+
+import chisel3._
+import chisel3.util._
+
+class SIMDTopIO() extends Bundle {
+  val csr = new CsrReqRspIO(SIMDConstant.csrAddrWidth)
+  val data = new SIMDDataIO()
+}
+
+// post-processing SIMD with uniformed interface: csr (snax side) and data ports (streamer side)
+class SIMDTop() extends Module with RequireAsyncReset {
+
+  val io = IO(new SIMDTopIO())
+
+  val csrManager = Module(
+    new CsrManager(SIMDConstant.csrNum, SIMDConstant.csrAddrWidth)
+  )
+  val simd = Module(new SIMD())
+
+  // io.csr and csrManager input connection
+  csrManager.io.csr_config_in <> io.csr
+
+  // csrManager output and simd control port connection
+  // control signals
+  simd.io.ctrl.valid := csrManager.io.csr_config_out.valid
+  csrManager.io.csr_config_out.ready := simd.io.ctrl.ready
+
+  // splitting csrManager data ports to the simd configuration ports
+  // the meanings of these ports can be found at PE.scala
+  // the order is also the same as at PE.scala
+  // as each control input port is 8 bits so 4 control input port shares 1 csr
+  simd.io.ctrl.bits.input_zp_i := csrManager.io.csr_config_out
+    .bits(0)(7, 0)
+    .asSInt
+  simd.io.ctrl.bits.output_zp_i := csrManager.io.csr_config_out
+    .bits(0)(15, 8)
+    .asSInt
+
+  // this control input port is 32 bits, so it needs 1 csr
+  simd.io.ctrl.bits.multiplier_i := csrManager.io.csr_config_out.bits(2).asSInt
+
+  simd.io.ctrl.bits.shift_i :=
+    csrManager.io.csr_config_out.bits(0)(23, 16).asSInt
+  simd.io.ctrl.bits.max_int_i :=
+    csrManager.io.csr_config_out.bits(0)(31, 24).asSInt
+
+  simd.io.ctrl.bits.min_int_i :=
+    csrManager.io.csr_config_out.bits(1)(7, 0).asSInt
+
+  // this control input port is only 1 bit
+  simd.io.ctrl.bits.double_round_i :=
+    csrManager.io.csr_config_out.bits(1)(8).asBool
+
+  io.data <> simd.io.data
+
+}
+
+object SIMDTop extends App {
+  emitVerilog(
+    new (SIMDTop),
+    Array("--target-dir", "generated/simd")
+  )
+}

--- a/src/test/scala/simd/SIMDTopTest.scala
+++ b/src/test/scala/simd/SIMDTopTest.scala
@@ -174,7 +174,7 @@ class SIMDTopAutoTest
         Seq(WriteVcdAnnotation)
       ) { dut =>
         // set test number
-        val testNum = 1
+        val testNum = 100
 
         // random test data generation
         for (i <- 1 to testNum) {

--- a/src/test/scala/simd/SIMDTopTest.scala
+++ b/src/test/scala/simd/SIMDTopTest.scala
@@ -1,0 +1,228 @@
+package simd
+
+import chisel3._
+import org.scalatest.flatspec.AnyFlatSpec
+import chiseltest._
+import scala.math.BigInt
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.Tag
+
+import java.lang.Integer.parseInt
+
+trait HasSIMDTopTestUtils extends HasSIMDTestUtils {
+
+  // write csr helper function
+  def write_csr[T <: SIMDTop](dut: T, addr: Int, data: String) = {
+
+    // give the data and address to the right ports
+    dut.io.csr.req.bits.write.poke(1.B)
+    dut.io.csr.req.bits.data.poke(data.U)
+    dut.io.csr.req.bits.addr.poke(addr.U)
+    dut.io.csr.req.valid.poke(1.B)
+
+    // wait for grant
+    while (dut.io.csr.req.ready.peekBoolean() == false) {
+      dut.clock.step(1)
+    }
+
+    dut.clock.step(1)
+
+    dut.io.csr.req.valid.poke(0.B)
+
+  }
+
+  // read csr helper function
+  def read_csr[T <: SIMDTop](dut: T, addr: Int, data: String) = {
+    dut.clock.step(1)
+
+    // give the data and address to the right ports
+    dut.io.csr.req.bits.write.poke(0.B)
+    dut.io.csr.req.bits.data.poke(data.U)
+    dut.io.csr.req.bits.addr.poke(addr.U)
+    dut.io.csr.req.valid.poke(1.B)
+
+    // wait for grant
+    while (dut.io.csr.req.ready.peekBoolean() == false) {
+      dut.clock.step(1)
+    }
+
+    // wait for valid signal
+    while (dut.io.csr.rsp.valid.peekBoolean() == false) {
+      dut.clock.step(1)
+    }
+
+    // return read csr result
+    val result: UInt = dut.io.csr.rsp.bits.data.peek()
+
+    dut.clock.step(1)
+
+    dut.io.csr.req.valid.poke(0.B)
+
+    // give read out ready signal
+    dut.io.csr.rsp.ready.poke(1.B)
+
+    result
+  }
+
+  // give dut random generated configuration
+  def configCsr[T <: SIMDTop](
+      dut: T,
+      input_zp: Byte,
+      output_zp: Byte,
+      multiplier: Int,
+      shift: Byte,
+      max_int: Byte,
+      min_int: Byte,
+      doubleRound: Boolean
+  ) = {
+
+    // csr 0 content according to csr definition
+    val csr_0 = "x" + String.format("%02X", max_int) + String.format(
+      "%02X",
+      shift
+    ) + String.format("%02X", output_zp) + String.format("%02X", input_zp)
+
+    // csr 1 content according to csr definition
+    var csr_1 = ""
+    if (doubleRound) {
+      csr_1 = "x" + String.format("%02X", 1) + String.format("%02X", min_int)
+    } else {
+      csr_1 = "x" + String.format("%02X", min_int)
+    }
+
+    // csr 2 content according to csr definition
+    var csr_2 = "x" + String.format("%08X", multiplier)
+
+    // for start address
+    var csr_3 = "x" + String.format("%02X", 0)
+
+    // set configuration
+    write_csr(dut, 0, csr_0)
+    write_csr(dut, 1, csr_1)
+    write_csr(dut, 2, csr_2)
+
+    // start signal
+    write_csr(dut, 3, csr_3)
+
+    // read csr and check
+    assert(csr_0.U(32.W).litValue == read_csr(dut, 0, "x00").litValue)
+    assert(csr_1.U(32.W).litValue == read_csr(dut, 1, "x00").litValue)
+    assert(csr_2.U(32.W).litValue == read_csr(dut, 2, "x00").litValue)
+
+  }
+
+  // give input data big bus to SIMDTop dut
+  def giveInputDataSIMDTop[T <: SIMDTop](dut: T, input: BigInt) = {
+    // giving input data
+    dut.clock.step()
+    dut.io.data.input_i.bits.poke(input)
+    dut.io.data.input_i.valid.poke(1.B)
+    while (dut.io.data.input_i.ready.peekBoolean() == false) {
+      dut.clock.step(1)
+    }
+    dut.clock.step()
+
+  }
+
+  // get output form SIMDTop dut and change to array type then verify with golden data
+  def checkSIMDOutputSIMDTop[T <: SIMDTop](
+      dut: T,
+      goldenValue: Array[Byte]
+  ) = {
+
+    // manually check SIMD output
+    dut.io.data.out_o.ready.poke(1.B)
+    while (dut.io.data.out_o.valid.peekBoolean() == false) {
+      dut.clock.step(1)
+    }
+    val out = dut.io.data.out_o.bits.peek()
+    // change big bus to array type
+    val outSeq = bus2vec(out)
+
+    // output array data verify with golden data
+    (outSeq zip goldenValue).foreach { case (out, golden) =>
+      assert(out == golden)
+    }
+
+  }
+
+  // give input and verify results
+  def verifyOutput[T <: SIMDTop](
+      dut: T,
+      input: BigInt,
+      goldenValue: Array[Byte]
+  ) = {
+
+    // give input
+    giveInputDataSIMDTop(dut, input)
+
+    // get output form dut and change to array type then verify with golden data
+    checkSIMDOutputSIMDTop(dut, goldenValue)
+
+  }
+
+}
+
+class SIMDTopAutoTest
+    extends AnyFlatSpec
+    with ChiselScalatestTester
+    with Matchers
+    with HasSIMDTopTestUtils {
+  "DUT" should "pass" in {
+    test(new SIMDTop)
+      .withAnnotations(
+        Seq(WriteVcdAnnotation)
+      ) { dut =>
+        // set test number
+        val testNum = 1
+
+        // random test data generation
+        for (i <- 1 to testNum) {
+          val (
+            input,
+            inputZp,
+            outputZp,
+            multiplier,
+            shift,
+            maxInt,
+            minInt,
+            doubleRound
+          ) = TestGen()
+
+          // input data sequence to a big bus
+          val inputBus = vec2bus(input)
+
+          // golden value gen
+          val goldenValue = goldenGen(
+            input,
+            inputZp,
+            outputZp,
+            multiplier,
+            shift,
+            maxInt,
+            minInt,
+            doubleRound
+          )
+
+          // give dut random generated configuration
+          configCsr(
+            dut,
+            inputZp,
+            outputZp,
+            multiplier,
+            shift,
+            maxInt,
+            minInt,
+            doubleRound
+          )
+
+          // give dut input test data and verify result
+          verifyOutput(
+            dut,
+            inputBus,
+            goldenValue
+          )
+        }
+      }
+  }
+}


### PR DESCRIPTION
Add the CsrManager for the Post-Processing SIMD datapath to be compatible with the SNAX CSR interface.

![image](https://github.com/KULeuven-MICAS/snax-postprocessing-simd/assets/143962462/a4587e05-e011-486d-8d62-467edbb2dce7)

The CsrManager code is the same as for GEMM and Streamer!